### PR TITLE
mark `nose` as testing requirement, not rum-time requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,10 @@ config = {
     'author_email': 'tylucaskelley@gmail.com',
     'license': 'MIT',
     'install_requires': [
-        'nose',
         'jsonschema'
+    ],
+    'tests_require': [
+        'nose',
     ],
     'packages': [
         'bx'


### PR DESCRIPTION
This patch tested via `pip install -e .` in a clean venv.